### PR TITLE
Use beforeEach() for DayCard tests

### DIFF
--- a/src/components/dayCard/DayCard.test.js
+++ b/src/components/dayCard/DayCard.test.js
@@ -3,49 +3,45 @@ import DayCard from './DayCard';
 import Wind from '../../assets/icons/wind.svg';
 
 describe('DayCard', () => {
+  beforeEach(() => {
+    render(
+      <DayCard
+        date='March 2nd'
+        day='Saturday'
+        description='light rain'
+        imgAltText='wind icon'
+        imgSrc={Wind}
+        temperature='36'
+      />
+    );
+  });
+
   test('it renders the day of the week', () => {
-    render(<DayCard day='Saturday' />);
     const dayOfTheWeek = screen.getByText('Saturday');
     expect(dayOfTheWeek).toBeInTheDocument();
   });
 
   test('it renders the date', () => {
-    render(<DayCard day='Saturday' date='March 2nd' />);
     const dayOfTheWeek = screen.getByText('March 2nd');
     expect(dayOfTheWeek).toBeInTheDocument();
   });
 
   test('it renders the icon', () => {
-    render(
-      <DayCard
-        day='Saturday'
-        date='March 2nd'
-        imgSrc={Wind}
-        imgAltText='wind icon'
-      />
-    );
-
     const image = document.querySelector('img');
     expect(image.alt).toContain('wind icon');
   });
 
   test('it provides alt text for the icon by default', () => {
-    render(<DayCard day='Saturday' date='March 2nd' imgSrc={Wind} />);
-
     const image = document.querySelector('img');
     expect(image.alt).toContain('wind');
   });
 
   test('it displays the temperature in celsius', () => {
-    render(<DayCard temperature='36' />);
-
     const temperature = screen.getByText('36 °C');
     expect(temperature).toBeInTheDocument();
   });
 
   test('it displays the weather description', () => {
-    render(<DayCard description='light rain' />);
-
     const weatherDescription = screen.getByText('light rain');
     expect(weatherDescription).toBeInTheDocument();
   });


### PR DESCRIPTION
Summary:
There was a lot of repetition going on with rendering the `DayCard` component for each test, so, I've put it in a `beforeEach()` block to solve this.